### PR TITLE
Fix bug in chat history interface and settings

### DIFF
--- a/application/interfaces/chat_history_repository.py
+++ b/application/interfaces/chat_history_repository.py
@@ -1,25 +1,18 @@
 from abc import ABC, abstractmethod
 from typing import List
+
 from domain.entities.chat_turn import ChatTurn
 
 
 class ChatHistoryRepository(ABC):
+    """Interface for persisting and retrieving chat history."""
 
-    @abstractmethod
-    def get_history(self, user_id: str) -> list:
-        pass
-
-    @abstractmethod
-    def save_history(self, user_id: str, history: list) -> None:
-        pass
-
-
-class ChatHistoryRepository(ABC):
     @abstractmethod
     def get_history(self, user_id: str) -> List[ChatTurn]:
-        # Validate or sanitize user_id to prevent path traversal or invalid characters
-        user_id = "".join(c for c in user_id if c.isalnum() or c in ("-", "_"))
+        """Return the stored chat history for ``user_id``."""
+        pass
 
     @abstractmethod
     def save_history(self, user_id: str, history: List[ChatTurn]) -> None:
+        """Persist the chat ``history`` for ``user_id``."""
         pass

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,11 +1,14 @@
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
+    openai_api_key: str | None = None
     allow_dangerous_deserialization: bool = False
 
     class Config:
         env_file = ".env"
         extra = "allow"
 
-def get_settings():
+
+def get_settings() -> Settings:
     return Settings()


### PR DESCRIPTION
## Summary
- remove duplicated ChatHistoryRepository definition
- add docstrings and return types
- allow providing `openai_api_key` from settings

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c14074e6c832caf9f34f5ed8a658b