### PR TITLE
Add sidebar UI and integrate in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,38 @@
-from presentation import streamlit_app
+import streamlit as st
+
+from presentation.ui.sidebar import sidebar
+from presentation.ui.upload_section import render_upload_section
+from presentation.ui.query_section import render_query_section
+from presentation.ui.annotations_section import render_annotation_section
+
+
+def main():
+    st.set_page_config(page_title="Whispero", page_icon="🧠", layout="wide")
+
+    uploaded_file, user_id = sidebar()
+
+    if uploaded_file and user_id:
+        if st.session_state.get("processed_file") != uploaded_file.name:
+            render_upload_section(uploaded_file, user_id)
+            st.session_state.processed_file = uploaded_file.name
+
+        col1, col2 = st.columns([1, 2])
+        with col1:
+            st.subheader("📝 Resumen del archivo")
+            st.write(f"**{uploaded_file.name}** cargado.")
+            if uploaded_file.name.lower().endswith(".csv"):
+                import pandas as pd
+
+                uploaded_file.seek(0)
+                df = pd.read_csv(uploaded_file)
+                st.dataframe(df.head())
+            render_annotation_section(user_id, uploaded_file.name)
+
+        with col2:
+            render_query_section(user_id)
+    else:
+        st.info("Confirma tu User ID y sube un archivo para comenzar.")
+
 
 if __name__ == "__main__":
-    streamlit_app.run()
+    main()

--- a/presentation/ui/sidebar.py
+++ b/presentation/ui/sidebar.py
@@ -1,32 +1,55 @@
+"""UI components for the application sidebar."""
+
 import streamlit as st
 from application.use_cases.session_use_case import SessionUseCase
 
 session_use_case = SessionUseCase()
 
 
-def render_sidebar():
-    st.sidebar.title("📚 Whispero")
+def sidebar():
+    """Render the application sidebar.
 
-    if "user_id" not in st.session_state:
-        user_input = st.sidebar.text_input("👤 User ID", key="user_id_input")
-        if st.sidebar.button("✅ Confirmar") and user_input:
-            st.session_state.user_id = user_input
-            session_use_case.create_session(user_input)
-            st.sidebar.success(f"Usuario {user_input} confirmado")
+    Returns
+    -------
+    tuple
+        Uploaded file and confirmed user ID if available.
+    """
 
-    uploaded_file = st.sidebar.file_uploader(
-        "📤 Subir archivo", type=["pdf", "docx", "csv"]
+    with st.sidebar:
+        st.markdown("## 🧠 Whispero")
+        st.markdown("---")
+
+        user_id = st.session_state.get("user_id")
+        if not user_id:
+            user_input = st.text_input("👤 User ID")
+            if st.button("✅ Confirmar") and user_input:
+                st.session_state.user_id = user_input
+                session_use_case.create_session(user_input)
+                user_id = user_input
+                st.success(f"Usuario {user_input} confirmado")
+        else:
+            st.write(f"**Usuario:** {user_id}")
+
+        uploaded_file = st.file_uploader(
+            "📤 Subir archivo", type=["pdf", "docx", "csv"]
+        )
+        if uploaded_file:
+            session_use_case.set_file(uploaded_file.name)
+            st.session_state.uploaded_file = uploaded_file
+            st.success(f"{uploaded_file.name} cargado")
+
+        st.markdown("---")
+        if st.button("🧹 Limpiar sesión"):
+            st.session_state.clear()
+
+        st.markdown("### ⚡ Acciones rápidas")
+        st.info("Espacio reservado para acciones rápidas")
+
+    return (
+        st.session_state.get("uploaded_file"),
+        st.session_state.get("user_id"),
     )
-    if uploaded_file:
-        session_use_case.set_file(uploaded_file.name)
-        st.session_state.uploaded_file = uploaded_file
-        st.sidebar.success(f"{uploaded_file.name} cargado")
 
-    # 3. Reset
-    st.sidebar.markdown("---")
-    if st.sidebar.button("🧹 Limpiar sesión"):
-        st.session_state.clear()
 
-    return st.session_state.get("uploaded_file", None), st.session_state.get(
-        "user_id", None
-    )
+# Backwards compatibility
+render_sidebar = sidebar


### PR DESCRIPTION
## Summary
- implement new `sidebar` function with logo, user id, uploader and reset button
- update `main.py` to use the sidebar directly and display upload/query/annotation sections
- show CSV preview when uploading CSV files

## Testing
- `black . --check`

------
https://chatgpt.com/codex/tasks/task_e_687f95c4371c832c82ee8e7e7c78f4f6